### PR TITLE
Add configuration option to use email as customer identifier for GoPe…

### DIFF
--- a/Block/ConsoleLog.php
+++ b/Block/ConsoleLog.php
@@ -103,6 +103,10 @@ class ConsoleLog extends Template
         return $this->_scopeConfig->getValue('gopersonal/general/client_id', ScopeInterface::SCOPE_STORE);
     }
 
+    public function useEmailAsCustomerIdentifier() {
+        return $this->_scopeConfig->isSetFlag('gopersonal/general/use_email_as_customer_identifier', ScopeInterface::SCOPE_STORE);
+    }
+
     public function getCartItems() {
         $items = [];
         foreach ($this->_checkoutSession->getQuote()->getAllVisibleItems() as $item) {

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "gopersonal/magento-plugin",
     "description": "Plugin for gopersonal personalization platform",
     "type": "magento2-module",
-    "version": "1.0.24",
+    "version": "2.0.0",
     "license": [
         "OSL-3.0",
         "AFL-3.0"

--- a/etc/adminhtml/system.xml
+++ b/etc/adminhtml/system.xml
@@ -25,6 +25,12 @@
                     <comment>When enabled, GoPersonal search will only run if the user has a valid JWT token. Useful for A/B testing scenarios.</comment>
                     <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
                 </field>
+
+                <field id="use_email_as_customer_identifier" translate="label" type="select" sortOrder="40" showInDefault="1" showInWebsite="1" showInStore="1">
+                    <label>Use Email as Customer Login Identifier</label>
+                    <comment>When enabled, GoPersonal will use the customer's email instead of Magento customer ID for SDK login.</comment>
+                    <source_model>Magento\Config\Model\Config\Source\Yesno</source_model>
+                </field>
             </group>
         </section>
     </system>

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -3,5 +3,5 @@
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd"
 >
-    <module name="Gopersonal_Magento" setup_version="1.0.23" />
+    <module name="Gopersonal_Magento" setup_version="2.0.0" />
 </config>

--- a/view/frontend/templates/console_log.phtml
+++ b/view/frontend/templates/console_log.phtml
@@ -79,6 +79,7 @@ require(['jquery'], function($) {
         async function fetchTokenAndCompare() {
             try {
                 const currentToken = window.gsSDK.getCurrentSession().token;
+                const useEmailAsCustomerIdentifier = <?= $block->useEmailAsCustomerIdentifier() ? 'true' : 'false' ?>;
                 // Fetch the token, customer ID, and email from the Magento API
                 const response = await fetch(window.location.origin + '/gopersonal/api/gettoken');
                 const data = await response.json();
@@ -93,7 +94,11 @@ require(['jquery'], function($) {
 
                 // Check if user is logged in and has valid data, then perform login on gsSDK
                 if (data.customer_id && data.customer_email) {
-                    window.gsSDK.login(data.customer_id, {
+                    const customerIdentifier = useEmailAsCustomerIdentifier
+                        ? data.customer_email
+                        : data.customer_id;
+
+                    window.gsSDK.login(customerIdentifier, {
                         email: data.customer_email,
                         param_updateCartFromCustomer: true
                     }).then(() => {

--- a/view/frontend/templates/console_log.phtml
+++ b/view/frontend/templates/console_log.phtml
@@ -79,7 +79,7 @@ require(['jquery'], function($) {
         async function fetchTokenAndCompare() {
             try {
                 const currentToken = window.gsSDK.getCurrentSession().token;
-                const useEmailAsCustomerIdentifier = <?= $block->useEmailAsCustomerIdentifier() ? 'true' : 'false' ?>;
+                const useEmailAsCustomerIdentifier = <?= json_encode($block->useEmailAsCustomerIdentifier()) ?>;
                 // Fetch the token, customer ID, and email from the Magento API
                 const response = await fetch(window.location.origin + '/gopersonal/api/gettoken');
                 const data = await response.json();


### PR DESCRIPTION
…rsonal SDK login

- Introduced a new setting in the admin panel to allow using the customer's email instead of the Magento customer ID for SDK login.
- Updated the ConsoleLog block to retrieve the new configuration setting.
- Modified the frontend template to utilize the new setting when logging in with the GoPersonal SDK.